### PR TITLE
#192776 order recreation + focus email fix + email hiding

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fastclick": "^1.0.6",
     "intl": "^1.2.5",
     "lodash-es": "^4.17.11",
+    "qs": "^6.9.1",
     "simple-assert": "^1.0.0",
     "vue": "^2.5.17",
     "vue-clickaway": "^2.2.2",

--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,7 @@ export default {
     window.addEventListener('resize', this.updateLayout);
   },
   methods: {
-    ...mapActions('PaymentForm', ['changePlatform']),
+    ...mapActions('PaymentForm', ['changePlatform', 'recreateOrder']),
 
     updateLayout() {
       this.isMobile = window.innerWidth < 640 || window.innerHeight < 510;
@@ -110,11 +110,6 @@ export default {
           window.location.replace(redirectUrl);
         }
       }
-    },
-
-    tryToBeginAgain() {
-      postMessage('TRY_TO_BEGIN_AGAIN');
-      window.location.reload();
     },
   },
 };
@@ -194,7 +189,7 @@ export default {
       v-bind="actionResult"
       :class="$style.orderCreationError"
       :isModal="isModalEssence"
-      @tryAgain="tryToBeginAgain"
+      @tryAgain="recreateOrder"
     />
 
     <div

--- a/src/components/FormSection.vue
+++ b/src/components/FormSection.vue
@@ -90,6 +90,7 @@ export default {
       'isUserCountryConfirmRequested',
       'isUserCountryRestricted',
       'userIpGeoData',
+      'isEmailFieldExposed',
       'isGeoFieldsExposed',
       'isZipInvalid',
       'currentPlatformId',
@@ -184,6 +185,7 @@ export default {
     this.paymentData.email = this.orderData.email;
     if (this.userIpGeoData) {
       this.paymentData.country = this.userIpGeoData.country;
+      this.paymentData.zip = this.userIpGeoData.zip;
     }
   },
 
@@ -191,7 +193,7 @@ export default {
     ...mapActions('PaymentForm', [
       'setActivePaymentMethodById',
       'createPayment',
-      'clearActionResult',
+      'recreateOrder',
       'usePaymentApi',
       'removeCard',
       'checkPaymentAccount',
@@ -214,8 +216,7 @@ export default {
           gtagEvent('clickOkButton', { event_category: 'userAction' });
           this.$emit('close');
         } else {
-          gtagEvent('clickTryAgainButton', { event_category: 'userAction' });
-          this.clearActionResult();
+          this.recreateOrder();
         }
       } else if (this.isPaymentFormVisible) {
         gtagEvent('clickPayButton', { event_category: 'userAction' });
@@ -318,6 +319,7 @@ export default {
           :countries="countries"
           :cards="cards"
           :cardNumberValidator="activePaymentMethod.account_regexp | getRegexp"
+          :isEmailFieldExposed="isEmailFieldExposed"
           :isGeoFieldsExposed="isGeoFieldsExposed"
           :isZipInvalid="isZipInvalid"
           @cardNumberChange="checkBankCardNumber"
@@ -336,6 +338,7 @@ export default {
             :label="$t('FormSection.abstractNumberPlaceholder', {name: activePaymentMethod.name})"
           />
           <UiTextField
+            v-if="isEmailFieldExposed"
             :class="$style.formItem"
             v-model="paymentData.email"
             type="email"

--- a/src/components/FormSectionBankCard.vue
+++ b/src/components/FormSectionBankCard.vue
@@ -40,7 +40,6 @@
         ref="cvvField"
         tabindex="4"
         :hasError="$isFieldInvalid('innerValue.cvv')"
-        @keyup.native="moveFocusToFieldOnComplete('cvv', 3, 'emailField')"
         @keyup.native.delete="moveFocusBackOnEmpty('cvv', 'expiryDateField')"
       />
     </div>
@@ -53,6 +52,7 @@
   />
 
   <UiTextField
+    v-if="isEmailFieldExposed"
     v-model="innerValue.email"
     ref="emailField"
     name="email"
@@ -62,7 +62,6 @@
     :hasError="$isFieldInvalid('innerValue.email')"
     :errorText="$t('FormSectionBankCard.emailInvalid')"
     :label="$t('FormSectionBankCard.email')"
-    @keyup.native.delete="moveFocusBackOnEmpty('email', 'cvvField')"
   />
   <template v-if="isGeoFieldsExposed">
     <UiSelect
@@ -190,6 +189,10 @@ export default {
     },
     countries: {
       type: Array,
+      required: true,
+    },
+    isEmailFieldExposed: {
+      type: Boolean,
       required: true,
     },
     isGeoFieldsExposed: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11188,6 +11188,11 @@ qs@^6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@^6.9.1:
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.1.tgz#20082c65cb78223635ab1a9eaca8875a29bf8ec9"
+  integrity sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA==
+
 query-string@^5.0.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"


### PR DESCRIPTION
Основное: пересоздание ордера после неудачи

Здесь же поправил:
1. Убрал автоматический перевод фокуса на поле email и обратно на cvv (https://protocol-one.slack.com/archives/CC8F2K8A3/p1574677253091000)
2. Скрываю поле email, если он приходит в данных ордера (https://protocol-one.slack.com/archives/CC8F2K8A3/p1574678741099400)
3. Валидация zip. Не работало, т.к ждало city